### PR TITLE
Update scalatest to 1.8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,9 @@
 name := "tlb-scalatest"
 
-version:= "1.0"
+version:= "1.1"
 
 libraryDependencies ++= Seq(
-    "org.scalatest" %% "scalatest" % "1.6.1" withSources(),
+    "org.scalatest" %% "scalatest" % "1.8" withSources(),
     "log4j" % "log4j" % "1.2.14"
 )
 

--- a/src/main/scala/org/scalatest/ScalaTestTLBSuite.scala
+++ b/src/main/scala/org/scalatest/ScalaTestTLBSuite.scala
@@ -23,7 +23,7 @@ class ScalaTestTLBSuite extends Suite {
 
   override def nestedSuites = {
     val loader = new URLClassLoader(Array(new File(jarFile).toURI.toURL), classOf[Suite].getClassLoader)
-    val accessibleSuites: Set[String] = (new SuiteDiscoveryHelper).discoverSuiteNames(List(jarFile), loader)
+    val accessibleSuites: Set[String] = SuiteDiscoveryHelper.discoverSuiteNames(List(jarFile), loader, None)
 
     val files = splitter.filterSuites(accessibleSuites.map(x => new TlbSuiteFileImpl(x)).toSeq)
     val orderedFiles = files.sorted(Ordering.comparatorToOrdering(orderer))


### PR DESCRIPTION
We had to update scalatest to version 1.8. We will also have to update scala to 2.10.0 in the next few days.
